### PR TITLE
Add basic combat

### DIFF
--- a/enemy.tscn
+++ b/enemy.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=1]
+
+[ext_resource path="res://scripts/enemy.gd" type="Script" id=1]
+[ext_resource path="res://resources/icon.png" type="Texture" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+
+custom_solver_bias = 0.0
+radius = 35.0
+
+[node name="enemy" type="KinematicBody2D"]
+
+input/pickable = false
+shapes/0/shape = SubResource( 1 )
+shapes/0/transform = Matrix32( 1, 0, 0, 1, 0, 0 )
+shapes/0/trigger = false
+collision/layers = 1
+collision/mask = 1
+collision/margin = 0.08
+script/script = ExtResource( 1 )
+
+[node name="sprite" type="Sprite" parent="."]
+
+texture = ExtResource( 2 )
+
+[node name="collision" type="CollisionShape2D" parent="."]
+
+shape = SubResource( 1 )
+trigger = false
+_update_shape_index = 0
+
+

--- a/engine.cfg
+++ b/engine.cfg
@@ -6,6 +6,7 @@ icon="res://icon.png"
 
 [input]
 
+attack=[mbutton(0, 1)]
 dash=[key(Space)]
 move_up=[key(W), key(Up)]
 move_down=[key(S), key(Down)]

--- a/player.tscn
+++ b/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=1]
+[gd_scene load_steps=5 format=1]
 
 [ext_resource path="res://scripts/player.gd" type="Script" id=1]
 [ext_resource path="res://resources/icon.png" type="Texture" id=2]
@@ -8,7 +8,12 @@
 custom_solver_bias = 0.0
 radius = 35.0
 
-[node name="character" type="KinematicBody2D"]
+[sub_resource type="CircleShape2D" id=2]
+
+custom_solver_bias = 0.0
+radius = 25.0
+
+[node name="player" type="KinematicBody2D"]
 
 input/pickable = false
 shapes/0/shape = SubResource( 1 )
@@ -48,5 +53,26 @@ drag_margin/bottom = 0.0
 shape = SubResource( 1 )
 trigger = false
 _update_shape_index = 0
+
+[node name="attackArea" type="Area2D" parent="."]
+
+input/pickable = true
+shapes/0/shape = SubResource( 2 )
+shapes/0/transform = Matrix32( 1, 0, 0, 1, 0, 0 )
+shapes/0/trigger = false
+gravity_vec = Vector2( 0, 1 )
+gravity = 98.0
+linear_damp = 0.1
+angular_damp = 1.0
+
+[node name="attackCollision" type="CollisionShape2D" parent="attackArea"]
+
+shape = SubResource( 2 )
+trigger = false
+_update_shape_index = 0
+
+[connection signal="body_enter" from="attackArea" to="." method="_on_attackArea_body_enter"]
+
+[connection signal="body_exit" from="attackArea" to="." method="_on_attackArea_body_exit"]
 
 

--- a/player.tscn
+++ b/player.tscn
@@ -11,7 +11,7 @@ radius = 35.0
 [sub_resource type="CircleShape2D" id=2]
 
 custom_solver_bias = 0.0
-radius = 25.0
+radius = 55.0
 
 [node name="player" type="KinematicBody2D"]
 

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -1,0 +1,4 @@
+extends KinematicBody2D
+
+func _ready():
+	add_to_group("Enemy")

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,10 +5,16 @@ const DASH_BOOST = 4 # Speed multiplier for the initial dash speed
 const DASH_DECAY = 1.15 # Rate at which the velocity decays after dashing
 const DASH_THRESHOLD = 1 # Speed at which the dash is considered over
 
+const MELEE_OFFSET = 50 # Distance of the melee collider with the attacker
+const MELEE_CD = 0.2 # Cooldown in seconds for the melee attacking
+
 export var speed = 300 # Normal movement speed in pixels/s
 var velocity = Vector2()
 var dashTimer = DASH_CD
 var dashing = false
+var attacking = true
+var attackTimer = MELEE_CD
+var targetsInRange = []
 
 func _ready():
 	set_fixed_process(true)
@@ -23,13 +29,13 @@ func _fixed_process(delta):
 	else:
 		# Handle user input and set velocity
 		velocity = Vector2()
-		if (Input.is_action_pressed("move_up")):
+		if Input.is_action_pressed("move_up"):
 			velocity.y -= 1
-		if (Input.is_action_pressed("move_down")):
+		if Input.is_action_pressed("move_down"):
 			velocity.y += 1
-		if (Input.is_action_pressed("move_left")):
+		if Input.is_action_pressed("move_left"):
 			velocity.x -= 1
-		if (Input.is_action_pressed("move_right")):
+		if Input.is_action_pressed("move_right"):
 			velocity.x += 1
 		velocity = velocity.normalized() * speed * delta
 		
@@ -40,4 +46,25 @@ func _fixed_process(delta):
 			velocity *= DASH_BOOST
 		elif dashTimer < DASH_CD:
 			dashTimer += delta
+			
+		# Attacking
+		if Input.is_action_pressed("attack") and not attacking and attackTimer >= MELEE_CD:
+			var direction = (get_global_mouse_pos() - get_pos()).normalized()
+			get_node("attackArea").set_pos(direction * MELEE_OFFSET)
+			attacking = true
+		elif attacking:
+			for target in targetsInRange:
+				if target.is_in_group("Enemy"):
+					print("Enemy hit!")
+			attacking = false
+			attackTimer = 0
+		else:
+			attackTimer += delta
+			
 	move(velocity)
+
+func _on_attackArea_body_enter(body):
+	targetsInRange.append(body)
+
+func _on_attackArea_body_exit(body):
+	targetsInRange.erase(body)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -47,7 +47,11 @@ func _fixed_process(delta):
 		elif dashTimer < DASH_CD:
 			dashTimer += delta
 			
-		# Attacking
+		# If the player is attacking, move the attack collider using the position of the mouse and
+		# set it to attacking mode. In attacking mode, it will get all targets which are in the
+		# attack collision area and deal the appropriate damage. This has to be done one frame after
+		# having moved the attack collider so all bodies entering after the movement are registered
+		# correctly. After the attack, send the attacking to cooldown.
 		if Input.is_action_pressed("attack") and not attacking and attackTimer >= MELEE_CD:
 			var direction = (get_global_mouse_pos() - get_pos()).normalized()
 			get_node("attackArea").set_pos(direction * MELEE_OFFSET)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,7 +5,7 @@ const DASH_BOOST = 4 # Speed multiplier for the initial dash speed
 const DASH_DECAY = 1.15 # Rate at which the velocity decays after dashing
 const DASH_THRESHOLD = 1 # Speed at which the dash is considered over
 
-const MELEE_OFFSET = 50 # Distance of the melee collider with the attacker
+const MELEE_OFFSET = 60 # Distance of the melee collider with the attacker
 const MELEE_CD = 0.2 # Cooldown in seconds for the melee attacking
 
 export var speed = 300 # Normal movement speed in pixels/s

--- a/test.tscn
+++ b/test.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=1]
+[gd_scene load_steps=5 format=1]
 
 [ext_resource path="res://tileset.tres" type="TileSet" id=1]
 [ext_resource path="res://scripts/test.gd" type="Script" id=2]
 [ext_resource path="res://player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://enemy.tscn" type="PackedScene" id=4]
 
 [node name="world" type="Node"]
 
@@ -28,5 +29,9 @@ script/script = ExtResource( 2 )
 [node name="player" parent="map" instance=ExtResource( 3 )]
 
 transform/pos = Vector2( 412.193, 284.318 )
+
+[node name="enemy" parent="map" instance=ExtResource( 4 )]
+
+transform/pos = Vector2( 556.108, 439.298 )
 
 


### PR DESCRIPTION
Allow player to attack by clicking the left mouse button. An area is moved in the direction of the mouse, with a constant offset from the attacker, which can be used to detect the targets that are in range of the attack. A cooldown is added for the attacking, making the player continuously attack in constant intervals while the attack button is pressed, being able to change the direction in real time. The body detection for the attack collider is done one frame after moving it, so all targets are added correctly.
Resolves #2 